### PR TITLE
Add default value for master domain relation

### DIFF
--- a/Configuration/TCA/Overrides/sys_domain.php
+++ b/Configuration/TCA/Overrides/sys_domain.php
@@ -16,6 +16,7 @@ if (!defined('TYPO3_MODE')) {
                 'internal_type' => 'db',
                 'allowed' => 'sys_domain',
                 'size' => '1',
+                'default' => 0,
                 'minitems' => '0',
                 'maxitems' => '1',
                 'wizards' => array(

--- a/Configuration/TCA/tx_naworkuri_uri.php
+++ b/Configuration/TCA/tx_naworkuri_uri.php
@@ -56,6 +56,7 @@ $GLOBALS['TCA']['tx_naworkuri_uri'] = array(
 			'config' => array(
 				'type' => 'select',
                 'renderType' => 'selectSingle',
+				'default' => 0,
 				'foreign_table' => 'sys_language',
 				'foreign_table_where' => 'ORDER BY sys_language.title',
 				'items' => array(
@@ -90,6 +91,7 @@ $GLOBALS['TCA']['tx_naworkuri_uri'] = array(
 			'config' => Array(
 				'type' => 'input',
 				'size' => '30',
+				'default' => '',
 			)
 		),
 		'path_hash' => Array(


### PR DESCRIPTION
Fix: #15
Fixes issue with TYPO3 8.7 and MySQL in strict mode.