### PR TITLE
FixEXT:lang language file path to support TYPO3 v8

### DIFF
--- a/Configuration/TCA/tx_naworkuri_uri.php
+++ b/Configuration/TCA/tx_naworkuri_uri.php
@@ -52,14 +52,14 @@ $GLOBALS['TCA']['tx_naworkuri_uri'] = array(
 		),
 		'sys_language_uid' => array(
 			'exclude' => 1,
-			'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.language',
+			'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.language',
 			'config' => array(
 				'type' => 'select',
                 'renderType' => 'selectSingle',
 				'foreign_table' => 'sys_language',
 				'foreign_table_where' => 'ORDER BY sys_language.title',
 				'items' => array(
-					array('LLL:EXT:lang/locallang_general.xml:LGL.default_value', 0)
+					array('LLL:EXT:lang/locallang_general.xlf:LGL.default_value', 0)
 				)
 			)
 		),


### PR DESCRIPTION
In TYPO3 v8 the file xlf files were moved to resources folder, but thanks to the compatibility layer old paths like LLL:EXT:lang/locallang_general.xlf can still be used.
However the path LLL:EXT:lang/locallang_general.xml is not working any more.
In order to support both v7 and v8 we should change the files to LLL:EXT:lang/locallang_general.xlf